### PR TITLE
Tau: use org.freedesktop.Sdk:20.08

### DIFF
--- a/org.gnome.Tau.yml
+++ b/org.gnome.Tau.yml
@@ -1,6 +1,6 @@
 app-id: org.gnome.Tau
 runtime: org.freedesktop.Platform
-runtime-version: "19.08"
+runtime-version: "20.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
Tested this build and LGTM. This could save some disk space on user machines since almost every app on Flathub already switched to new runtime.