### PR TITLE
build: Add finish-args: device=dri

### DIFF
--- a/org.gnome.Tau.yml
+++ b/org.gnome.Tau.yml
@@ -6,6 +6,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
 command: tau
 finish-args:
+  - --device=dri
   - --share=ipc
   - --socket=x11
   - --socket=wayland


### PR DESCRIPTION
For OpenGL rendering. According to talks with other maintainers this will not hurt and should been added to all gtk apps. Only if there some serious reasons to no adding it. Thanks in advance.