### PR TITLE
Mark Tau as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This application is no longer maintained."
+}


### PR DESCRIPTION
This application uses an old runtime that was marked as end-of-life (EOL) two years ago.

Fixes: https://github.com/flathub/org.gnome.Tau/issues/5